### PR TITLE
T/enable services after install

### DIFF
--- a/handlers/restarts.yml
+++ b/handlers/restarts.yml
@@ -7,13 +7,8 @@
   become: yes
 
 - name: restart opencast
-  action: service_facts
-  changed_when: true
-  notify: actually restart opencast
-
-- name: actually restart opencast
   action: service
     name=opencast
     state=restarted
-  when: not uninstall is defined and hostvars[inventory_hostname]['services']['opencast'] is defined
+  when: not uninstall is defined
   become: yes

--- a/handlers/restarts.yml
+++ b/handlers/restarts.yml
@@ -4,32 +4,16 @@
   action: service
     name=activemq
     state=restarted
-    enabled=yes
   become: yes
 
-  #FIXME: It's unclear why this shows up as OK, rather than SKIPPED
 - name: restart opencast
   action: service_facts
+  changed_when: true
   notify: actually restart opencast
 
 - name: actually restart opencast
   action: service
     name=opencast
     state=restarted
-    enabled=yes
   when: not uninstall is defined and hostvars[inventory_hostname]['services']['opencast'] is defined
-  become: yes
-
-- name: restart nginx
-  action: service
-    name=nginx
-    state=restarted
-    enabled=yes
-  become: yes
-
-- name: restart mariadb
-  action: service
-    name=mysql
-    state=restarted
-    enabled=true
   become: yes

--- a/roles/activemq-packages-install/tasks/main.yml
+++ b/roles/activemq-packages-install/tasks/main.yml
@@ -24,6 +24,12 @@
   become: yes
   when: ansible_distribution == "CentOS" or ansible_distribution == "Red Hat Enterprise Linux"
 
+- name: Enable ActiveMQ to start at bootup
+  service:
+    name: activemq
+    enabled: yes
+  become: yes
+ 
   #We do this since otherwise the rule isn't in the list of available services below, and the ansible module can't do this yet.
 - name: Loading ActiveMQ firewall rules
   shell: firewall-cmd --reload

--- a/roles/opencast-packages-install/tasks/main.yml
+++ b/roles/opencast-packages-install/tasks/main.yml
@@ -20,6 +20,13 @@
 - import_tasks: centos.yml
   when: ansible_distribution == "CentOS" or ansible_distribution == "Red Hat Enterprise Linux"
 
+
+- name: Enable Opencast to start at bootup
+  service:
+    name: opencast
+    enabled: yes
+  become: yes
+
 - name: Remounting NFS mount if appropriate
   mount:
     name: "{{ oc_storage_dir }}"


### PR DESCRIPTION
I fixed the FIXME (see first commit) but through the second handler was triggered it did not fire as opencast was not listed in the service_facts ( I checked with by running with -v which dumped out the details).

Permanent state such as enabled at bootup should be set as a task rather than by a handler