### PR TITLE
t/make database idempotent

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -30,6 +30,9 @@ oc_db_user: opencast
 #The database password
 oc_db_pass: opencast_db_passwd
 
+#The database schema's name, changing this is unwise at the moment.
+oc_db_schema: opencast
+
 #The username that Opencast should use to log into activemq
 activemq_oc_user: opencast
 #The password that Opencast should use to log into activemq

--- a/group_vars/geerlingguy.yml
+++ b/group_vars/geerlingguy.yml
@@ -29,10 +29,6 @@ nginx_vhosts:
 #This key makes innodb_large_prefix=1 and innodb_file_format=barracuda in /etc/mysql/my.cnf
 mysql_supports_innodb_large_prefix: False
 
-mysql_databases:
-  - name: "{{ oc_db_schema }}"
-    encoding: utf8
-    collation: utf8_general_ci
 # TODO: Handle setting appropriate host restictions
 mysql_users:
   - name: "{{ oc_db_user }}"

--- a/group_vars/opencast.yml
+++ b/group_vars/opencast.yml
@@ -6,9 +6,6 @@ oc_package_version: 6
 #The protocol for Opencast to use.  Defaults to http, should be changed to https for production use.
 oc_protocol: http
 
-#The database schema's name, changing this is unwise at the moment.
-oc_db_schema: opencast
-
 ### The directories below are the defaults for package based installs, do not change them.
 
 #Where the opencast base files live

--- a/roles/mariadb-config/tasks/main.yml
+++ b/roles/mariadb-config/tasks/main.yml
@@ -10,6 +10,14 @@
     - never
     - reset
 
+  # Try creating DB ourselves so can register change
+- name: Create the Opencast database
+  mysql_db:
+    name: "{{ oc_db_schema }}"
+    state: present
+  register: oc_database_created
+  become: yes
+
 - name: Copying schema to database server
   copy:
     src: mysql5.sql
@@ -17,7 +25,7 @@
     force: yes
   tags:
     - reset
-  when: not uninstall is defined
+  when: oc_database_created.changed and not uninstall is defined
 
 - name: Importing Opencast database schema
   mysql_db:
@@ -26,5 +34,5 @@
     target: "/tmp/mysql5.sql"
   tags:
     - reset
-  when: not uninstall is defined
+  when: oc_database_created.changed and not uninstall is defined
   become: yes

--- a/roles/mariadb-config/tasks/main.yml
+++ b/roles/mariadb-config/tasks/main.yml
@@ -17,6 +17,8 @@
     state: present
   register: oc_database_created
   become: yes
+  tags:
+    - reset
 
 - name: Copying schema to database server
   copy:


### PR DESCRIPTION
We want to know when the opencast database is created, so use our own task instead of the geerlingguy role. Note the schema variable is required by the database groups as well as the opencast and so should be in all 